### PR TITLE
Add standalone drum machine scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ __Metronome__ - has a slider that controls the BMP and sets the global BPM in it
 
 __Keyboard__ - loads synth configurations remotely from the server. Includees distortion and delay effects. Handles live WebMidi events to the selected synth
 
-__Drum Machine__ - A controller for generic step sequencer elements
+__Drum Machine__ - A controller for generic step sequencer elements. The current Phaser app boots directly
+into the drum machine so you can load the default seed grooves and generate new beats with the built-in
+Magenta-powered AI.
 
 __Recorder__ - Basic recording of inputs - can handle mic or software inputs
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,5 +1,5 @@
 import 'phaser';
-import DashboardScene from './scenes/main'
+import DrumMachineScene from './scenes/drumMachineScene'
 import PreloadScene from './scenes/preload';
 
 const DEFAULT_WIDTH = 1280;
@@ -15,7 +15,7 @@ const config = {
     width: DEFAULT_WIDTH,
     height: DEFAULT_HEIGHT
   },
-  scene: [PreloadScene, DashboardScene],
+  scene: [PreloadScene, DrumMachineScene],
 
 };
 

--- a/src/scenes/drumMachineScene.ts
+++ b/src/scenes/drumMachineScene.ts
@@ -1,0 +1,46 @@
+import 'phaser';
+import { generateColor } from '../helpers/PhaserHelpers';
+import DrumMachine from '../components/drumMachine';
+import TransportControl from '../components/transportControl';
+
+export default class DrumMachineScene extends Phaser.Scene {
+  private helpText: Phaser.GameObjects.Text;
+  private logText: Phaser.GameObjects.Text;
+  private drumMachine: DrumMachine;
+  private transport: TransportControl;
+
+  constructor() {
+    super({ key: 'DrumMachineScene' });
+  }
+
+  create() {
+    this.add.rectangle(0, 0, 1280, 720, generateColor(), 0.15).setOrigin(0);
+
+    this.helpText = this.add
+      .text(30, 25, 'Load a seed pattern then press AI to create a new beat.', {
+        fontSize: '22px',
+        color: '#000000',
+      })
+      .setDepth(2);
+
+    this.logText = this.add
+      .text(30, 55, 'Starter patterns ready. Press Play to hear them.', {
+        fontSize: '14px',
+        color: '#000000',
+      })
+      .setDepth(2);
+
+    this.drumMachine = new DrumMachine(this, 30, 110, this.helpText, this.logText);
+
+    this.transport = new TransportControl(this, 1020, 575, this.helpText);
+
+    // Load a default groove so the AI generator has a seed to build from.
+    this.drumMachine.loadSeq('PATTERN_Rock Beat 1');
+    this.helpText.setText('Press Play to listen, then tap AI to generate a new beat.');
+  }
+
+  update() {
+    this.drumMachine?.update();
+    this.transport?.update();
+  }
+}

--- a/src/scenes/preload.ts
+++ b/src/scenes/preload.ts
@@ -39,7 +39,7 @@ export default class PreloadScene extends Phaser.Scene {
         this.load.on('complete', function () {
             //console.log('complete');
             assetText.destroy();
-            this.scene.start('DashboardScene')
+            this.scene.start('DrumMachineScene')
         }, this);
 
 


### PR DESCRIPTION
## Summary
- add a dedicated DrumMachineScene that focuses on AI-assisted drum beats
- update the preload flow and game configuration to boot directly into the drum machine experience
- document the new drum-machine-first experience

## Testing
- npm run build *(fails: rollup uglify const parsing @magenta/music es5 bundle)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb135219083318b6099c595179287)